### PR TITLE
fix some build error

### DIFF
--- a/unix/CMakeLists.txt
+++ b/unix/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(unix_dlfcn dlfcn.c)
 
 find_package(Threads)
 
+target_link_libraries(unix_dlfcn -ldl)
+
 target_link_libraries(unix_pthread Threads::Threads)
 target_link_libraries(unix_pthread_mutex Threads::Threads)
 target_link_libraries(unix_pthread_cond Threads::Threads)

--- a/unix/dlfcn.c
+++ b/unix/dlfcn.c
@@ -10,6 +10,7 @@ int main(int argc, char *argv[])
     if (!handler)
     {
         printf("open lib failed: %s\n", dlerror());
+        return -1;
     }
 
     printf_t dl_printf = dlsym(handler, "printf");

--- a/unix/dlfcn.c
+++ b/unix/dlfcn.c
@@ -18,4 +18,6 @@ int main(int argc, char *argv[])
     dl_printf("this is dl_printf\n");
 
     dlclose(handler);
+
+    return 0;
 }

--- a/unix/pthread.c
+++ b/unix/pthread.c
@@ -5,16 +5,20 @@
 
 static void *thread_entry(void *arg)
 {
-    printf("%p\n", arg);
+    printf("data addr: %p(after)\n", arg);
 
     return 0;
 }
 
 int main(int argc, char *argv[])
 {
+    static unsigned char data = 0xaa;
+    printf("data addr: %p(before)\n", &data);
     pthread_t thread;
-    pthread_create(&thread, NULL, thread_entry, argv);
+    pthread_create(&thread, NULL, thread_entry, &data);
     pthread_detach(thread);
 
     sleep(1);
+
+    return 0;
 }


### PR DESCRIPTION
fix some build error under `unix` path

```
    ➜  /home/mi/xiaomi/note/unix/build git:(main) ✗ make
    Scanning dependencies of target unix_pthread
    Scanning dependencies of target unix_pthread_mutex
    Scanning dependencies of target unix_pthread_cond
    Scanning dependencies of target unix_dlfcn
    Scanning dependencies of target unix_poll
    Scanning dependencies of target unix_select
    [ 33%] Building C object CMakeFiles/unix_dlfcn.dir/dlfcn.o
    [ 33%] Building C object CMakeFiles/unix_pthread_mutex.dir/pthread_mutex.o
    [ 33%] Building C object CMakeFiles/unix_pthread.dir/pthread.o
    [ 41%] Building C object CMakeFiles/unix_pthread_cond.dir/pthread_cond.o
    [ 41%] Building C object CMakeFiles/unix_poll.dir/poll.o
    [ 50%] Building C object CMakeFiles/unix_select.dir/select.o
    [ 58%] Linking C executable unix_dlfcn
    [ 75%] Linking C executable unix_pthread_mutex
    [ 83%] Linking C executable unix_pthread
    [ 83%] Linking C executable unix_pthread_cond
    [ 91%] Linking C executable unix_select
    [100%] Linking C executable unix_poll
    /usr/bin/ld: CMakeFiles/unix_dlfcn.dir/dlfcn.o: in function `main':
    dlfcn.c:(.text+0x20): undefined reference to `dlopen'
    /usr/bin/ld: dlfcn.c:(.text+0x30): undefined reference to `dlerror'
    /usr/bin/ld: dlfcn.c:(.text+0x5e): undefined reference to `dlsym'
    /usr/bin/ld: dlfcn.c:(.text+0x80): undefined reference to `dlclose'
    collect2: error: ld returned 1 exit status
    make[2]: *** [CMakeFiles/unix_dlfcn.dir/build.make:84: unix_dlfcn] Error 1
    make[1]: *** [CMakeFiles/Makefile2:86: CMakeFiles/unix_dlfcn.dir/all] Error 2
    make[1]: *** Waiting for unfinished jobs....
    [100%] Built target unix_pthread_mutex
    [100%] Built target unix_pthread
    [100%] Built target unix_pthread_cond
    [100%] Built target unix_select
    [100%] Built target unix_poll
    make: *** [Makefile:84: all] Error 2
```

- unix/CMakeLists.txt: fix build error
- unix/dlfcn.c: add return for main entry
- unix/dlfcn.c: return -1 if dlopen fail