### PR TITLE
fix select timeout busy loop

### DIFF
--- a/unix/select.c
+++ b/unix/select.c
@@ -8,19 +8,23 @@
 int main(int argc, char *argv[])
 {
     fd_set         read_fds = {};
-    struct timeval tv;
     int            retval = 0;
 
     FD_ZERO(&read_fds);
     FD_SET(0, &read_fds);
 
-    tv.tv_sec  = 5;
-    tv.tv_usec = 0;
+    printf("select wailing\n");
 
-    printf("select wailing");
+    /* Let the last log can be output */
+    fflush(stdout);
 
     while (true)
     {
+        struct timeval tv = {
+            .tv_sec  = 5,
+            .tv_usec = 0
+        };
+
         retval = select(1, &read_fds, NULL, NULL, &tv);
 
         if (retval == -1)
@@ -52,6 +56,11 @@ int main(int argc, char *argv[])
                     }
                 }
             }
+        }
+        else if (retval == 0)
+        {
+            printf("select timeout ......\n");
+            continue;
         }
         else
         {


### PR DESCRIPTION
After the select function executes and returns, the value of the timeval structure passed in will be cleared, so the timeout time of select must be reset every time.

Change before, once timeout, will busy loop:
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......
select timeout ......

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>