### PR TITLE
linux/inotify.c: replace IN_MOVE with IN_ALL_EVENTS for test

### DIFF
--- a/linux/inotify.c
+++ b/linux/inotify.c
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
         goto err;
     }
 
-    int ret = inotify_add_watch(ifd, "./", IN_MOVED_TO | IN_MOVED_FROM);
+    int ret = inotify_add_watch(ifd, "./", IN_ALL_EVENTS);
     if (ret < 0)
     {
         perror("inotify add failed");


### PR DESCRIPTION
Reference:
https://man7.org/linux/man-pages/man7/inotify.7.html?userCode=wrvvs1rm

The `IN_ALL_EVENTS` macro is defined as a bit mask of all of the
above events.  This macro can be used as the mask argument when
calling inotify_add_watch(2).

Two additional convenience macros are defined:
- IN_MOVE: Equates to IN_MOVED_FROM | IN_MOVED_TO.
- IN_CLOSE: Equates to IN_CLOSE_WRITE | IN_CLOSE_NOWRITE.

Signed-off-by: Junbo Zheng <3273070@qq.com>