### PR TITLE
python: fix build break

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach (TARGET ${TARGETS})
     )
     # windows平台的路径是 '\'，添加宏的时候，要把路径里的 ’\’，替换为 '\\'
     # 如果是c++，可使用 R“”，不转义字符串，如：-DPYTHONHOME=R"${PYTHONHOME}"
-    string(REGEX REPLACE "[\\]" "\\\\\\\\" PYTHONHOME ${Python3_ROOT})
+    string(REGEX REPLACE "[\\]" "\\\\\\\\" PYTHONHOME "${Python3_ROOT}")
     target_compile_definitions(${TARGET} PRIVATE -DPYTHONHOME="${PYTHONHOME}")
 endforeach ()
 


### PR DESCRIPTION
python: fix build break

build result

```
-- The C compiler identification is GNU 13.1.0
-- The CXX compiler identification is GNU 13.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-> subdirectory: /home/mi/local/note/android
-> subdirectory: /home/mi/local/note/boost
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-> subdirectory: /home/mi/local/note/c
-> subdirectory: /home/mi/local/note/cpp
-> subdirectory: /home/mi/local/note/cuda
-> subdirectory: /home/mi/local/note/darwin
-> subdirectory: /home/mi/local/note/libuv
-> subdirectory: /home/mi/local/note/linux
-> subdirectory: /home/mi/local/note/opencv
-> subdirectory: /home/mi/local/note/pybind11
-> subdirectory: /home/mi/local/note/python
-- Found Python3: /usr/include/python3.8 (found version "3.8.10") found components: Development Development.Module Development.Embed
CMake Error at python/CMakeLists.txt:29 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.

-> subdirectory: /home/mi/local/note/qt
-> subdirectory: /home/mi/local/note/rust
-> subdirectory: /home/mi/local/note/unix
-> subdirectory: /home/mi/local/note/win
-- Configuring incomplete, errors occurred!
```

Reference: 
- https://stackoverflow.com/questions/66525264/cmake-errorstring-sub-command-replace-requires-at-least-four-arguments
- https://stackoverflow.com/questions/26585513/cmake-error-with-string-sub-command-strip-requires-two-arguments

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>