### PR TITLE
unix: fix build break

### DIFF
--- a/unix/CMakeLists.txt
+++ b/unix/CMakeLists.txt
@@ -14,6 +14,10 @@ note_generate_target(./ unix TARGETS)
 find_package(Threads)
 
 foreach (TARGET ${TARGETS})
+    if (${TARGET} STREQUAL "unix_dlfcn")
+        target_link_libraries(${TARGET} -ldl)
+    endif()
+
     target_link_libraries(${TARGET} Threads::Threads)
     set_target_properties(
             ${TARGET}


### PR DESCRIPTION
unix: fix build break

```
➜  /home/mi/local/note git:(main) ✗ cmake --build build -j16
-> subdirectory: /home/mi/local/note/android
-> subdirectory: /home/mi/local/note/boost
-> subdirectory: /home/mi/local/note/c
-> subdirectory: /home/mi/local/note/cpp
-> subdirectory: /home/mi/local/note/cuda
-> subdirectory: /home/mi/local/note/darwin
-> subdirectory: /home/mi/local/note/libuv
-> subdirectory: /home/mi/local/note/linux
-> subdirectory: /home/mi/local/note/pybind11
-> subdirectory: /home/mi/local/note/qt
-> subdirectory: /home/mi/local/note/rust
-> subdirectory: /home/mi/local/note/unix
-> subdirectory: /home/mi/local/note/win
-- Configuring done (0.0s)
-- Generating done (0.0s)
-- Build files have been written to: /home/mi/local/note/build
[  3%] Built target c_restrict
[  9%] Built target cpp_concept
[ 11%] Built target cpp_container
[ 17%] Built target cpp_condition_variable
[ 19%] Built target cpp_coroutine
[ 26%] Built target cpp_future_async
[ 30%] Built target cpp_format
[ 30%] Built target cpp_future_promise
[ 34%] Built target cpp_iostream
[ 38%] Built target cpp_semaphore
[ 42%] Built target cpp_smart_pointer
[ 46%] Built target cpp_string
[ 50%] Built target cpp_mutex
[ 53%] Built target cpp_thread
[ 57%] Built target cpp_ranges
[ 61%] Built target runso
[ 63%] Linking C executable ../run/unix_dlfcn
[ 67%] Built target linux_epoll
[ 71%] Built target linux_inotify
[ 75%] Built target unix_pthread
[ 80%] Built target unix_poll
[ 84%] Built target linux_minichat
[ 86%] Built target unix_pthread_cond
[ 90%] Built target unix_pthread_mutex
[ 94%] Built target unix_select
[ 98%] Built target boost_asio
/usr/bin/ld: CMakeFiles/unix_dlfcn.dir/dlfcn.c.o: in function `main':
dlfcn.c:(.text+0x23): undefined reference to `dlopen'
/usr/bin/ld: dlfcn.c:(.text+0x33): undefined reference to `dlerror'
/usr/bin/ld: dlfcn.c:(.text+0x67): undefined reference to `dlsym'
/usr/bin/ld: dlfcn.c:(.text+0x8c): undefined reference to `dlclose'
collect2: error: ld returned 1 exit status
make[2]: *** [unix/CMakeFiles/unix_dlfcn.dir/build.make:97: run/unix_dlfcn] Error 1
make[1]: *** [CMakeFiles/Makefile2:876: unix/CMakeFiles/unix_dlfcn.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

Reference: https://github.com/buyuer/note/pull/2/commits/4e818732ffc33202056c1cb06457ca2e87486209

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>