### PR TITLE
unix: fix typo

### DIFF
--- a/unix/CMakeLists.txt
+++ b/unix/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(Threads)
 
 foreach (TARGET ${TARGETS})
     if (${TARGET} STREQUAL "unix_dlfcn")
-        target_link_libraries(${TARGET} -ldl)
+        target_link_libraries(${TARGET} dl)
     endif()
 
     target_link_libraries(${TARGET} Threads::Threads)


### PR DESCRIPTION
Should't use `-l` option for target link library

Reference:
- [target_link_libraries(<target> ... <item>... ...)](https://cmake.org/cmake/help/latest/command/target_link_libraries.html#overview)
```
target_link_libraries(<target> ... <item>... ...)
A plain library name: The generated link line will ask the linker to search for the library (e.g. foo becomes -lfoo or foo.lib).
```

<img width="670" alt="image" src="https://github.com/buyuer/note/assets/19257159/d5343c36-6f10-49d3-bc0e-dc3aa0a2409a">

Signed-off-by: Junbo Zheng <3273070@qq.com>