### PR TITLE
python: fix build warning

### DIFF
--- a/python/embed.c
+++ b/python/embed.c
@@ -40,8 +40,8 @@ void print_from_py(const char *str, long num)
 
 int main(int argc, char *argv[])
 {
-    const char *env_pyhome = "PYTHONHOME=" PYTHONHOME;
-    const char *env_pypath = "PYTHONPATH=" PYTHONHOME "/lib";
+    char *env_pyhome = "PYTHONHOME=" PYTHONHOME;
+    char *env_pypath = "PYTHONPATH=" PYTHONHOME "/lib";
 
     putenv(env_pyhome);
     putenv(env_pypath);


### PR DESCRIPTION
python: fix build warning
```
[ 42%] Building C object python/CMakeFiles/python_embed.dir/embed.c.o [ 44%] Building C object python/CMakeFiles/mypy.dir/mypy/mypy.c.o [ 46%] Building CXX object qt/CMakeFiles/qt_sync_file.dir/sync_file.cpp.o [ 48%] Linking CXX executable ../run/cpp_semaphore [ 50%] Linking CXX executable ../run/cpp_smart_pointer 2 warnings generated.
/Users/junbozheng/project/note/python/embed.c:46:12: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    putenv(env_pyhome);
           ^~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/stdlib.h:223:19: note: passing argument to parameter here
int      putenv(char *) __DARWIN_ALIAS(putenv);
                      ^
/Users/junbozheng/project/note/python/embed.c:47:12: warning: passing 'const char *' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
    putenv(env_pypath);
           ^~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/stdlib.h:223:19: note: passing argument to parameter here
int      putenv(char *) __DARWIN_ALIAS(putenv);
                      ^
[ 51%] Linking CXX executable ../run/cpp_coroutine
2 warnings generated.
[ 51%] Built target cpp_semaphore
[ 53%] Linking C executable ../run/python_embed
```
Signed-off-by: Junbo Zheng <3273070@qq.com>